### PR TITLE
Add authenticated create/update/delete routes and fix auth bypass

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from pydantic_settings import BaseSettings
 
 
@@ -10,6 +12,13 @@ class Settings(BaseSettings):
     secret_key: str
     algorithm: str
     access_token_expire_minutes: int
+    # Comma-separated list of origins allowed to send credentialed requests.
+    # Reads are public, so the default stays permissive for plain GETs.
+    cors_allow_origins: str = "*"
+
+    @property
+    def cors_origin_list(self) -> List[str]:
+        return [o.strip() for o in self.cors_allow_origins.split(",") if o.strip()]
 
     class Config:
         env_file = ".env"

--- a/app/main.py
+++ b/app/main.py
@@ -1,18 +1,34 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from . import models
+from .config import settings
 from .database import engine
 from .routers import programs, networks, stations, users, login, locations
 
 
 models.Base.metadata.create_all(bind=engine)
 
-app = FastAPI()
+# Controls the section order in /docs and /redoc. Tags not listed here fall to
+# the bottom; "default" holds any untagged route (currently GET /).
+openapi_tags = [
+    {"name": "Apply Within Programs"},
+    {"name": "Apply Within Programs by Network"},
+    {"name": "Apply Within Radio Stations"},
+    {"name": "Radio Station Locations"},
+    {"name": "Login"},
+    {"name": "default"},
+]
 
+app = FastAPI(openapi_tags=openapi_tags)
+
+# "*" and allow_credentials=True are mutually exclusive under the CORS spec --
+# browsers reject the combination. Auth here uses a Bearer header rather than
+# cookies, so credentialed CORS is only enabled when real origins are listed.
+cors_origins = settings.cors_origin_list
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=cors_origins,
+    allow_credentials="*" not in cors_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/app/oauth2.py
+++ b/app/oauth2.py
@@ -28,11 +28,13 @@ def create_access_token(data: dict):
 def verify_access_token(token: str, credentials_exception):
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        id: str = payload.get("user_id")
+        id = payload.get("user_id")
         if id is None:
             raise credentials_exception
-        token_data = schemas.TokenData(id=str(id))
-    except JWTError:
+        # Reject a non-numeric user_id here rather than letting int() blow up
+        # with a 500 further down.
+        token_data = schemas.TokenData(id=str(int(id)))
+    except (JWTError, TypeError, ValueError):
         raise credentials_exception
 
     return token_data
@@ -50,5 +52,11 @@ def get_current_user(
     token = verify_access_token(token, credentials_exception)
 
     user = db.query(models.User).filter(models.User.id == int(token.id)).first()
+
+    # A validly-signed token whose user has since been deleted must not
+    # authenticate. Without this the routes receive current_user=None and
+    # still run.
+    if user is None:
+        raise credentials_exception
 
     return user

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -4,11 +4,27 @@ from sqlalchemy.orm import Session
 from sqlalchemy import desc, or_
 import datetime
 from ..database import get_db
-from .. import schemas, models
+from .. import schemas, models, oauth2
 
 router = APIRouter(prefix="/v1/locations", tags=["Radio Station Locations"])
 
 today = datetime.date.today().isoformat()
+
+
+def _get_location_or_404(idLocation: int, db: Session) -> models.LOCATION:
+    location = (
+        db.query(models.LOCATION)
+        .filter(models.LOCATION.idLocation == idLocation)
+        .first()
+    )
+
+    if not location:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Location with id: {idLocation} does not exist",
+        )
+
+    return location
 
 
 # Get list of locations
@@ -59,3 +75,80 @@ def get_location(
             detail="Database did not return any locations",
         )
     return locations
+
+
+@router.post(
+    "/",
+    status_code=status.HTTP_201_CREATED,
+    summary="Add a location",
+    response_model=schemas.LocationBase,
+)
+def create_location(
+    location: schemas.LocationCreate,
+    db: Session = Depends(get_db),
+    current_user: int = Depends(oauth2.get_current_user),
+):
+    """
+    Add a location to the database.
+    """
+    new_location = models.LOCATION(**location.model_dump())
+    db.add(new_location)
+    db.commit()
+    db.refresh(new_location)
+
+    return new_location
+
+
+@router.patch(
+    "/{idLocation}",
+    status_code=status.HTTP_200_OK,
+    summary="Update a location",
+    response_model=schemas.LocationBase,
+)
+def patch_location(
+    idLocation: int,
+    location: schemas.LocationUpdate,
+    db: Session = Depends(get_db),
+    current_user: int = Depends(oauth2.get_current_user),
+):
+    """
+    Partially update a location. Only the fields sent are changed.
+    """
+    existing = _get_location_or_404(idLocation, db)
+
+    updates = location.model_dump(exclude_unset=True)
+    if not updates:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No fields provided to update.",
+        )
+
+    for field, value in updates.items():
+        setattr(existing, field, value)
+
+    db.commit()
+    db.refresh(existing)
+
+    return existing
+
+
+@router.delete(
+    "/{idLocation}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a location",
+)
+def delete_location(
+    idLocation: int,
+    db: Session = Depends(get_db),
+    current_user: int = Depends(oauth2.get_current_user),
+):
+    """
+    Delete a location and unlink it from any stations.
+    """
+    location = _get_location_or_404(idLocation, db)
+
+    location.stations.clear()
+    db.delete(location)
+    db.commit()
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/routers/login.py
+++ b/app/routers/login.py
@@ -8,8 +8,8 @@ router = APIRouter(prefix="/v1", tags=["Login"])
 
 @router.post(
     "/login",
+    summary="Log in and get an access token",
     response_model=schemas.Token,
-    include_in_schema=False,
 )
 def login(
     user_credentials: OAuth2PasswordRequestForm = Depends(),

--- a/app/routers/programs.py
+++ b/app/routers/programs.py
@@ -11,6 +11,18 @@ router = APIRouter(prefix="/v1", tags=["Apply Within Programs"])
 today = datetime.date.today().isoformat()
 
 
+def _get_program_or_404(id: int, db: Session) -> models.APWI:
+    program = db.query(models.APWI).filter(models.APWI.id == id).first()
+
+    if not program:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Program with id: {id} does not exist",
+        )
+
+    return program
+
+
 # Get list of programs ordered by descending date
 @router.get(
     "/programs",
@@ -65,7 +77,6 @@ def get_programs(
     "/programs",
     status_code=status.HTTP_201_CREATED,
     response_model=schemas.ProgramBase,
-    include_in_schema=False,
 )
 def create_program(
     program: schemas.ProgramCreate,
@@ -82,3 +93,58 @@ def create_program(
     db.refresh(new_program)
 
     return new_program
+
+
+@router.patch(
+    "/programs/{id}",
+    status_code=status.HTTP_200_OK,
+    summary="Update a program",
+    response_model=schemas.ProgramBase,
+)
+def patch_program(
+    id: int,
+    program: schemas.ProgramUpdate,
+    db: Session = Depends(get_db),
+    current_user: int = Depends(oauth2.get_current_user),
+):
+    """
+    Partially update a program. Only the fields sent are changed.
+    """
+    existing = _get_program_or_404(id, db)
+
+    updates = program.model_dump(exclude_unset=True)
+    if not updates:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No fields provided to update.",
+        )
+
+    for field, value in updates.items():
+        # airdate is stored as a string column, so normalise the parsed date.
+        setattr(existing, field, value.isoformat() if field == "airdate" else value)
+
+    db.commit()
+    db.refresh(existing)
+
+    return existing
+
+
+@router.delete(
+    "/programs/{id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a program",
+)
+def delete_program(
+    id: int,
+    db: Session = Depends(get_db),
+    current_user: int = Depends(oauth2.get_current_user),
+):
+    """
+    Delete a program.
+    """
+    program = _get_program_or_404(id, db)
+
+    db.delete(program)
+    db.commit()
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/routers/stations.py
+++ b/app/routers/stations.py
@@ -11,6 +11,26 @@ router = APIRouter(prefix="/v1", tags=["Apply Within Radio Stations"])
 today = datetime.date.today().isoformat()
 
 
+def _get_station_or_404(idStation: int, db: Session) -> models.STATION:
+    station = (
+        db.query(models.STATION)
+        .options(
+            joinedload(models.STATION.locations),
+            joinedload(models.STATION.airtimes),
+        )
+        .filter(models.STATION.idStation == idStation)
+        .first()
+    )
+
+    if not station:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Station with id: {idStation} does not exist",
+        )
+
+    return station
+
+
 @router.get(
     "/stations",
     status_code=status.HTTP_200_OK,
@@ -61,12 +81,26 @@ async def get_stations(
     return stations
 
 
+@router.get(
+    "/stations/{idStation}",
+    status_code=status.HTTP_200_OK,
+    summary="Get a single radio station",
+    response_model=schemas.StationBase,
+)
+def get_station(idStation: int, db: Session = Depends(get_db)):
+    """
+    Get one radio station by id.
+    """
+    station = _get_station_or_404(idStation, db)
+
+    return station
+
+
 @router.post(
     "/stations",
     status_code=status.HTTP_201_CREATED,
     summary="Add a radio station",
     response_model=schemas.StationBase,
-    include_in_schema=False,
 )
 def post_stations(
     station: schemas.StationCreate,
@@ -76,9 +110,69 @@ def post_stations(
     """
     Add a radio station to the database
     """
-    new_station = models.STATION(**station.model_dump())
+    # by_alias maps call_letters -> the "callletters" DB column.
+    new_station = models.STATION(**station.model_dump(by_alias=True))
     db.add(new_station)
     db.commit()
     db.refresh(new_station)
-    
+
     return new_station
+
+
+@router.patch(
+    "/stations/{idStation}",
+    status_code=status.HTTP_200_OK,
+    summary="Update a radio station",
+    response_model=schemas.StationBase,
+)
+def patch_station(
+    idStation: int,
+    station: schemas.StationUpdate,
+    db: Session = Depends(get_db),
+    current_user: int = Depends(oauth2.get_current_user),
+):
+    """
+    Partially update a radio station. Only the fields sent are changed.
+    """
+    existing = _get_station_or_404(idStation, db)
+
+    # exclude_unset keeps an omitted field from being overwritten with None.
+    updates = station.model_dump(exclude_unset=True)
+    if not updates:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No fields provided to update.",
+        )
+
+    for field, value in updates.items():
+        # The model column is "callletters"; the API exposes "call_letters".
+        setattr(existing, "callletters" if field == "call_letters" else field, value)
+
+    db.commit()
+    db.refresh(existing)
+
+    return existing
+
+
+@router.delete(
+    "/stations/{idStation}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a radio station",
+)
+def delete_station(
+    idStation: int,
+    db: Session = Depends(get_db),
+    current_user: int = Depends(oauth2.get_current_user),
+):
+    """
+    Delete a radio station and its location/airtime links.
+    """
+    station = _get_station_or_404(idStation, db)
+
+    # Clear the association rows first so the junction tables don't orphan.
+    station.locations.clear()
+    station.airtimes.clear()
+    db.delete(station)
+    db.commit()
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -36,7 +36,7 @@ class LocationBase(BaseModel):
         from_attributes = True
 
 
-class LocationCreate(LocationBase):
+class LocationCreate(BaseModel):
     city: str
     state: str
     country: str
@@ -73,9 +73,43 @@ class StationBase(BaseModel):
 
 class StationCreate(BaseModel):
     network: str
-    url: Optional[str]
-    image: Optional[str]
+    url: Optional[str] = None
+    image: Optional[str] = None
     name: str
+    frequency: Optional[str] = None
+    live: Optional[bool] = False
+    local: Optional[bool] = False
+    call_letters: Optional[str] = Field(default=None, serialization_alias="callletters")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class StationUpdate(BaseModel):
+    """PATCH body -- every field optional; only what is sent gets changed."""
+
+    network: Optional[str] = None
+    url: Optional[str] = None
+    image: Optional[str] = None
+    name: Optional[str] = None
+    frequency: Optional[str] = None
+    live: Optional[bool] = None
+    local: Optional[bool] = None
+    call_letters: Optional[str] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ProgramUpdate(BaseModel):
+    airdate: Optional[date] = None
+    title: Optional[str] = None
+    network: Optional[str] = None
+    filename: Optional[str] = None
+
+
+class LocationUpdate(BaseModel):
+    city: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = None
 
 
 class CallLettersBase(BaseModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ email-validator==2.3.0
 fastapi==0.116.1
 greenlet==3.2.4
 h11==0.16.0
+httpx==0.28.1
 idna==3.10
 iniconfig==2.1.0
 isort==6.0.1
@@ -30,8 +31,8 @@ pluggy==1.6.0
 psycopg2-binary==2.9.10
 pyasn1==0.6.1
 pycparser==2.22
-pydantic==2.11.7
 pydantic-settings==2.10.1
+pydantic==2.11.7
 pydantic_core==2.33.2
 Pygments==2.19.2
 pylint==3.3.8
@@ -49,8 +50,8 @@ sortedcontainers==2.4.0
 SQLAlchemy==2.0.43
 starlette==0.47.3
 tomlkit==0.13.3
-trio==0.30.0
 trio-websocket==0.12.2
+trio==0.30.0
 typing-inspection==0.4.1
 typing_extensions==4.14.1
 urllib3==2.5.0


### PR DESCRIPTION
Adds POST/PATCH/DELETE for stations, programs, and locations behind login (reads stay public), fixes an auth-bypass where tokens for deleted users authenticated as None, corrects invalid CORS config, and un-hides the write routes plus /v1/login in /docs with explicit section ordering.